### PR TITLE
modern: fix constants and remove File prefixed streams.

### DIFF
--- a/lib/modern.js
+++ b/lib/modern.js
@@ -156,10 +156,10 @@ exports.write = function write(fd, buffer, offset, length, position) {
   });
 };
 
-exports.F_OK = fs.F_OK || 0;
-exports.R_OK = fs.R_OK || 0;
-exports.W_OK = fs.W_OK || 0;
-exports.X_OK = fs.X_OK || 0;
+exports.F_OK = fs.constants.F_OK || 0;
+exports.R_OK = fs.constants.R_OK || 0;
+exports.W_OK = fs.constants.W_OK || 0;
+exports.X_OK = fs.constants.X_OK || 0;
 
 exports.Dirent = fs.Dirent;
 exports.Stats = fs.Stats;
@@ -179,22 +179,6 @@ Object.defineProperties(exports, {
     },
     set(val) {
       fs.WriteStream = val;
-    }
-  },
-  FileReadStream: {
-    get() {
-      return fs.FileReadStream;
-    },
-    set(val) {
-      fs.FileReadStream = val;
-    }
-  },
-  FileWriteStream: {
-    get() {
-      return fs.FileWriteStream;
-    },
-    set(val) {
-      fs.FileWriteStream = val;
     }
   },
   promises: {


### PR DESCRIPTION
I could not find FileReadStream and FileWriteStream in fs docs for nodejs v8+.
So dropping them.