### PR TITLE
pkg: add type lints.

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -12,7 +12,12 @@ const features = require('./features');
  * Expose
  */
 
-if (features.HAS_ALL)
-  module.exports = require('./modern');
-else
-  module.exports = require('./legacy');
+if (features.HAS_ALL) {
+  const modern = require('./modern');
+
+  module.exports = modern;
+} else {
+  const legacy = require('./legacy');
+
+  module.exports = legacy;
+}

--- a/lib/compat.js
+++ b/lib/compat.js
@@ -224,6 +224,10 @@ function mkdirpSync(dir, mode) {
   }
 }
 
+/**
+ * @returns {Array} [args, recursive]
+ */
+
 function mkdirArgs(path, options) {
   let mode = null;
   let recursive = false;
@@ -261,13 +265,24 @@ async function mkdir(path, options) {
   return call(fs.mkdir, args);
 }
 
+/**
+ * Synchronously creates a directory.
+ * @param {fs.PathLike} path
+ * @param {{
+ *   recursive?: boolean;
+ *   mode?: string | number;
+ *   } | number} [options]
+ * @returns {string | void}
+ */
+
 function mkdirSync(path, options) {
   const [args, recursive] = mkdirArgs(path, options);
 
   if (recursive)
     return mkdirpSync(...args);
 
-  return fs.mkdirSync(...args);
+  const [argPath, argMode] = args;
+  return fs.mkdirSync(argPath, argMode);
 }
 
 /*
@@ -281,11 +296,19 @@ async function open(...args) {
   return call(fs.open, args);
 }
 
-function openSync(...args) {
-  if (args[1] == null)
-    args[1] = 'r';
+/**
+ * Synchronously opens a file.
+ * @param {fs.PathLike} path
+ * @param {string | number} [flags]
+ * @param {string | number} [mode]
+ * @returns {number}
+ */
 
-  return fs.openSync(...args);
+function openSync(path, flags, mode) {
+  if (flags == null)
+    flags = 'r';
+
+  return fs.openSync(path, flags, mode);
 }
 
 /*
@@ -299,6 +322,7 @@ async function read(...args) {
 
 function readSync(...args) {
   args[1] = toBuffer(args[1]);
+  // @ts-ignore
   return fs.readSync(...args);
 }
 
@@ -330,6 +354,7 @@ async function readdir(...args) {
 function readdirSync(...args) {
   const [dir, options] = args;
   const withFileTypes = options && options.withFileTypes;
+  // @ts-ignore
   const list = fs.readdirSync(...args);
 
   if (!withFileTypes || fs.Dirent)
@@ -429,7 +454,9 @@ class Dir {
   _error() {
     const err = new Error('Directory handle was closed');
 
+    // @ts-ignore
     err.code = 'ERR_DIR_CLOSED';
+    // @ts-ignore
     err.name = `Error [${err.code}]`;
 
     if (Error.captureStackTrace)
@@ -524,12 +551,26 @@ realpath.native = async function(...args) {
   return call(fs.realpath, args);
 };
 
-function realpathSync(...args) {
-  return fs.realpathSync(...args);
+/**
+ * Returns the resolved pathname.
+ * @param {fs.PathLike} p
+ * @param {fs.EncodingOption} [options]
+ * @returns {string | Buffer}
+ */
+
+function realpathSync(p, options) {
+  return fs.realpathSync(p, options);
 }
 
-realpathSync.native = function(...args) {
-  return fs.realpathSync(...args);
+/**
+ * Returns the resolved pathname.
+ * @param {fs.PathLike} p
+ * @param {fs.EncodingOption} [options]
+ * @returns {string | Buffer}
+ */
+
+realpathSync.native = function(p, options) {
+  return fs.realpathSync(p, options);
 };
 
 /*
@@ -825,6 +866,7 @@ function writeSync(...args) {
   if (typeof args[1] !== 'string')
     args[1] = toBuffer(args[1]);
 
+  // @ts-ignore
   return fs.writeSync(...args);
 }
 
@@ -843,6 +885,7 @@ function writeFileSync(...args) {
   if (typeof args[1] !== 'string')
     args[1] = toBuffer(args[1]);
 
+  // @ts-ignore
   return fs.writeFileSync(...args);
 }
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -39,6 +39,22 @@ class ArgError extends TypeError {
 }
 
 /**
+ * TypeError w/ code.
+ */
+
+class TypeCodeError extends TypeError {
+  constructor(msg, code = '') {
+    super(msg);
+
+    this.code = code;
+    this.name = `TypeError [${this.code}]`;
+
+    if (Error.captureStackTrace)
+      Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/**
  * FSError
  */
 
@@ -143,3 +159,4 @@ FSError.EISDIR = {
 
 exports.ArgError = ArgError;
 exports.FSError = FSError;
+exports.TypeCodeError = TypeCodeError;

--- a/lib/extra.js
+++ b/lib/extra.js
@@ -8,7 +8,7 @@
 
 const path = require('path');
 const error = require('./error');
-const fs = require('./backend');
+const backend = require('./backend');
 const util = require('./util');
 const {dirname, join, resolve} = path;
 const {ArgError, FSError} = error;
@@ -57,7 +57,7 @@ async function _copy(src, dest, options, seen, depth) {
       let real = resolve(src);
 
       try {
-        real = await fs.realpath(real);
+        real = await backend.realpath(real);
       } catch (e) {
         if (!isIgnorable(e))
           throw e;
@@ -69,17 +69,17 @@ async function _copy(src, dest, options, seen, depth) {
       seen.add(real);
     }
 
-    const list = await fs.readdir(src);
+    const list = await backend.readdir(src);
 
     if (dstat) {
       if (!dstat.isDirectory())
         throw new FSError(EEXIST, 'mkdir', dest);
     } else {
-      await fs.mkdir(dest, sstat.mode);
+      await backend.mkdir(dest, sstat.mode);
     }
 
     if (options.timestamps)
-      await fs.utimes(dest, sstat.atime, sstat.mtime);
+      await backend.utimes(dest, sstat.atime, sstat.mtime);
 
     for (const name of list) {
       ret += await _copy(join(src, name),
@@ -101,13 +101,13 @@ async function _copy(src, dest, options, seen, depth) {
         throw new FSError(EEXIST, 'symlink', dest);
       }
 
-      await fs.unlink(dest);
+      await backend.unlink(dest);
     }
 
-    await fs.symlink(await fs.readlink(src), dest);
+    await backend.symlink(await backend.readlink(src), dest);
 
     if (options.timestamps)
-      await fs.utimes(dest, sstat.atime, sstat.mtime);
+      await backend.utimes(dest, sstat.atime, sstat.mtime);
 
     return ret;
   }
@@ -122,13 +122,13 @@ async function _copy(src, dest, options, seen, depth) {
       }
 
       if (!dstat.isFile())
-        await fs.unlink(dest);
+        await backend.unlink(dest);
     }
 
-    await fs.copyFile(src, dest, options.flags);
+    await backend.copyFile(src, dest, options.flags);
 
     if (options.timestamps)
-      await fs.utimes(dest, sstat.atime, sstat.mtime);
+      await backend.utimes(dest, sstat.atime, sstat.mtime);
 
     return ret;
   }
@@ -166,7 +166,7 @@ function _copySync(src, dest, options, seen, depth) {
       let real = resolve(src);
 
       try {
-        real = fs.realpathSync(real);
+        real = backend.realpathSync(real);
       } catch (e) {
         if (!isIgnorable(e))
           throw e;
@@ -178,17 +178,17 @@ function _copySync(src, dest, options, seen, depth) {
       seen.add(real);
     }
 
-    const list = fs.readdirSync(src);
+    const list = backend.readdirSync(src);
 
     if (dstat) {
       if (!dstat.isDirectory())
         throw new FSError(EEXIST, 'mkdir', dest);
     } else {
-      fs.mkdirSync(dest, sstat.mode);
+      backend.mkdirSync(dest, sstat.mode);
     }
 
     if (options.timestamps)
-      fs.utimesSync(dest, sstat.atime, sstat.mtime);
+      backend.utimesSync(dest, sstat.atime, sstat.mtime);
 
     for (const name of list) {
       ret += _copySync(join(src, name),
@@ -210,13 +210,13 @@ function _copySync(src, dest, options, seen, depth) {
         throw new FSError(EEXIST, 'symlink', dest);
       }
 
-      fs.unlinkSync(dest);
+      backend.unlinkSync(dest);
     }
 
-    fs.symlinkSync(fs.readlinkSync(src), dest);
+    backend.symlinkSync(backend.readlinkSync(src), dest);
 
     if (options.timestamps)
-      fs.utimesSync(dest, sstat.atime, sstat.mtime);
+      backend.utimesSync(dest, sstat.atime, sstat.mtime);
 
     return ret;
   }
@@ -231,13 +231,13 @@ function _copySync(src, dest, options, seen, depth) {
       }
 
       if (!dstat.isFile())
-        fs.unlinkSync(dest);
+        backend.unlinkSync(dest);
     }
 
-    fs.copyFileSync(src, dest, options.flags);
+    backend.copyFileSync(src, dest, options.flags);
 
     if (options.timestamps)
-      fs.utimesSync(dest, sstat.atime, sstat.mtime);
+      backend.utimesSync(dest, sstat.atime, sstat.mtime);
 
     return ret;
   }
@@ -251,7 +251,7 @@ async function empty(path, mode) {
   let list = null;
 
   try {
-    list = await fs.readdir(dir);
+    list = await backend.readdir(dir);
   } catch (e) {
     if (e.code === 'ENOENT')
       return mkdirp(dir, mode);
@@ -270,7 +270,7 @@ function emptySync(path, mode) {
   let list = null;
 
   try {
-    list = fs.readdirSync(dir);
+    list = backend.readdirSync(dir);
   } catch (e) {
     if (e.code === 'ENOENT')
       return mkdirpSync(dir, mode);
@@ -285,10 +285,10 @@ function emptySync(path, mode) {
 
 async function exists(file, mode) {
   if (mode == null)
-    mode = fs.constants.F_OK;
+    mode = backend.constants.F_OK;
 
   try {
-    await fs.access(file, mode);
+    await backend.access(file, mode);
     return true;
   } catch (e) {
     if (isIgnorable(e))
@@ -299,10 +299,10 @@ async function exists(file, mode) {
 
 function existsSync(file, mode) {
   if (mode == null)
-    mode = fs.constants.F_OK;
+    mode = backend.constants.F_OK;
 
   try {
-    fs.accessSync(file, mode);
+    backend.accessSync(file, mode);
     return true;
   } catch (e) {
     if (isIgnorable(e))
@@ -313,7 +313,7 @@ function existsSync(file, mode) {
 
 async function lstatTry(...args) {
   try {
-    return await fs.lstat(...args);
+    return await backend.lstat(...args);
   } catch (e) {
     if (isIgnorable(e))
       return null;
@@ -321,9 +321,9 @@ async function lstatTry(...args) {
   }
 }
 
-function lstatTrySync(...args) {
+function lstatTrySync(path, options) {
   try {
-    return fs.lstatSync(...args);
+    return backend.lstatSync(path, options);
   } catch (e) {
     if (isIgnorable(e))
       return null;
@@ -335,19 +335,19 @@ async function mkdirp(dir, mode) {
   if (mode == null)
     mode = 0o777;
 
-  return fs.mkdir(dir, { mode, recursive: true });
+  return backend.mkdir(dir, { mode, recursive: true });
 }
 
 function mkdirpSync(dir, mode) {
   if (mode == null)
     mode = 0o777;
 
-  return fs.mkdirSync(dir, { mode, recursive: true });
+  return backend.mkdirSync(dir, { mode, recursive: true });
 }
 
 async function move(src, dest) {
   try {
-    await fs.rename(src, dest);
+    await backend.rename(src, dest);
     return;
   } catch (e) {
     if (e.code !== 'EXDEV')
@@ -360,7 +360,7 @@ async function move(src, dest) {
 
 function moveSync(src, dest) {
   try {
-    fs.renameSync(src, dest);
+    backend.renameSync(src, dest);
     return;
   } catch (e) {
     if (e.code !== 'EXDEV')
@@ -387,7 +387,7 @@ async function outputFile(path, data, options) {
     mode |= (mode & 0o444) >>> 2;
 
   await mkdirp(dir, mode);
-  await fs.writeFile(file, data, options);
+  await backend.writeFile(file, data, options);
 }
 
 function outputFileSync(path, data, options) {
@@ -406,19 +406,19 @@ function outputFileSync(path, data, options) {
     mode |= (mode & 0o444) >>> 2;
 
   mkdirpSync(dir, mode);
-  fs.writeFileSync(file, data, options);
+  backend.writeFileSync(file, data, options);
 }
 
 async function readJSON(path, options) {
   const [reviver, opt] = readJSONOptions(options);
-  const text = await fs.readFile(path, opt);
+  const text = await backend.readFile(path, opt);
 
   return decodeJSON(text, reviver);
 }
 
 function readJSONSync(path, options) {
   const [reviver, opt] = readJSONOptions(options);
-  const text = fs.readFileSync(path, opt);
+  const text = backend.readFileSync(path, opt);
 
   return decodeJSON(text, reviver);
 }
@@ -484,7 +484,7 @@ async function _remove(path, options, depth) {
     let list = null;
 
     try {
-      list = await fs.readdir(path);
+      list = await backend.readdir(path);
     } catch (e) {
       if (e.code === 'ENOENT')
         return ret;
@@ -496,7 +496,7 @@ async function _remove(path, options, depth) {
 
     if (ret === 0) {
       try {
-        await fs.rmdir(path);
+        await backend.rmdir(path);
       } catch (e) {
         if (e.code === 'ENOENT')
           return ret;
@@ -508,7 +508,7 @@ async function _remove(path, options, depth) {
   }
 
   try {
-    await fs.unlink(path);
+    await backend.unlink(path);
   } catch (e) {
     if (e.code === 'ENOENT')
       return ret;
@@ -578,7 +578,7 @@ function _removeSync(path, options, depth) {
     let list = null;
 
     try {
-      list = fs.readdirSync(path);
+      list = backend.readdirSync(path);
     } catch (e) {
       if (e.code === 'ENOENT')
         return ret;
@@ -593,7 +593,7 @@ function _removeSync(path, options, depth) {
 
       for (;;) {
         try {
-          fs.rmdirSync(path);
+          backend.rmdirSync(path);
         } catch (e) {
           if (e.code === 'ENOENT')
             return ret;
@@ -616,7 +616,7 @@ function _removeSync(path, options, depth) {
   }
 
   try {
-    fs.unlinkSync(path);
+    backend.unlinkSync(path);
   } catch (e) {
     if (e.code === 'ENOENT')
       return ret;
@@ -628,7 +628,7 @@ function _removeSync(path, options, depth) {
 
 async function statTry(...args) {
   try {
-    return await fs.stat(...args);
+    return await backend.stat(...args);
   } catch (e) {
     if (isIgnorable(e))
       return null;
@@ -636,9 +636,9 @@ async function statTry(...args) {
   }
 }
 
-function statTrySync(...args) {
+function statTrySync(path, options) {
   try {
-    return fs.statSync(...args);
+    return backend.statSync(path, options);
   } catch (e) {
     if (isIgnorable(e))
       return null;
@@ -651,14 +651,14 @@ async function stats(file, options) {
 
   if (options.follow) {
     try {
-      return await fs.stat(file, options.stat);
+      return await backend.stat(file, options.stat);
     } catch (e) {
       if (!isIgnorable(e))
         throw e;
     }
   }
 
-  return fs.lstat(file, options.stat);
+  return backend.lstat(file, options.stat);
 }
 
 function statsSync(file, options) {
@@ -666,14 +666,14 @@ function statsSync(file, options) {
 
   if (options.follow) {
     try {
-      return fs.statSync(file, options.stat);
+      return backend.statSync(file, options.stat);
     } catch (e) {
       if (!isIgnorable(e))
         throw e;
     }
   }
 
-  return fs.lstatSync(file, options.stat);
+  return backend.lstatSync(file, options.stat);
 }
 
 async function statsTry(file, options) {
@@ -758,14 +758,14 @@ async function writeJSON(path, json, options) {
   const [args, opt] = writeJSONOptions(options);
   const text = encodeJSON(json, args);
 
-  return fs.writeFile(path, text, opt);
+  return backend.writeFile(path, text, opt);
 }
 
 function writeJSONSync(path, json, options) {
   const [args, opt] = writeJSONOptions(options);
   const text = encodeJSON(json, args);
 
-  fs.writeFileSync(path, text, opt);
+  backend.writeFileSync(path, text, opt);
 }
 
 /**
@@ -822,7 +822,7 @@ class AsyncWalker {
       let real = resolve(path);
 
       try {
-        real = await fs.realpath(real);
+        real = await backend.realpath(real);
       } catch (e) {
         if (!isIgnorable(e))
           throw e;
@@ -837,7 +837,7 @@ class AsyncWalker {
     let list = null;
 
     try {
-      list = await fs.readdir(path);
+      list = await backend.readdir(path);
     } catch (e) {
       if (isIgnorable(e))
         return;
@@ -903,7 +903,7 @@ function* syncWalker(path, options) {
       let real = resolve(path);
 
       try {
-        real = fs.realpathSync(real);
+        real = backend.realpathSync(real);
       } catch (e) {
         if (!isIgnorable(e))
           throw e;
@@ -918,7 +918,7 @@ function* syncWalker(path, options) {
     let list = null;
 
     try {
-      list = fs.readdirSync(path);
+      list = backend.readdirSync(path);
     } catch (e) {
       if (isIgnorable(e))
         return;
@@ -965,7 +965,7 @@ function copyOptions(options) {
     follow = false;
 
   if (overwrite == null)
-    overwrite = (flags & fs.constants.COPYFILE_EXCL) === 0;
+    overwrite = (flags & backend.constants.COPYFILE_EXCL) === 0;
 
   if (timestamps == null)
     timestamps = false;
@@ -986,9 +986,9 @@ function copyOptions(options) {
     throw new ArgError('timestamps', timestamps, 'boolean');
 
   if (overwrite)
-    flags &= ~fs.constants.COPYFILE_EXCL;
+    flags &= ~backend.constants.COPYFILE_EXCL;
   else
-    flags |= fs.constants.COPYFILE_EXCL;
+    flags |= backend.constants.COPYFILE_EXCL;
 
   return {
     flags,
@@ -1253,15 +1253,15 @@ function wait(ms) {
 
 async function safeStat(path) {
   try {
-    return await fs.lstat(path);
+    return await backend.lstat(path);
   } catch (e) {
     if (e.code === 'EPERM' && process.platform === 'win32') {
       try {
-        await fs.chmod(path, 0o666);
+        await backend.chmod(path, 0o666);
       } catch (e) {
         ;
       }
-      return fs.lstat(path);
+      return backend.lstat(path);
     }
     throw e;
   }
@@ -1269,15 +1269,15 @@ async function safeStat(path) {
 
 function safeStatSync(path) {
   try {
-    return fs.lstatSync(path);
+    return backend.lstatSync(path);
   } catch (e) {
     if (e.code === 'EPERM' && process.platform === 'win32') {
       try {
-        fs.chmodSync(path, 0o666);
+        backend.chmodSync(path, 0o666);
       } catch (e) {
         ;
       }
-      return fs.lstatSync(path);
+      return backend.lstatSync(path);
     }
     throw e;
   }

--- a/lib/features.js
+++ b/lib/features.js
@@ -15,9 +15,9 @@ const fs = require('fs');
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 const parts = process.version.split(/[^\d]/);
 const version = (0
-  + (parts[1] & 0xff) * 0x10000
-  + (parts[2] & 0xff) * 0x00100
-  + (parts[3] & 0xff) * 0x00001);
+  + (Number(parts[1]) & 0xff) * 0x10000
+  + (Number(parts[2]) & 0xff) * 0x00100
+  + (Number(parts[3]) & 0xff) * 0x00001);
 
 // fs.Stats got millisecond times in 8.1.0.
 let HAS_STAT_NUMBERS = version >= 0x080100;

--- a/lib/fs-browser.js
+++ b/lib/fs-browser.js
@@ -223,8 +223,10 @@ exports.readFileSync = enoentSync('open');
 exports.readlink = enoent('readlink');
 exports.readlinkSync = enoentSync('readlink');
 exports.realpath = enoent('stat');
+// @ts-ignore
 exports.realpath.native = enoent('stat');
 exports.realpathSync = enoentSync('stat');
+// @ts-ignore
 exports.realpathSync.native = enoentSync('stat');
 exports.rename = noop;
 exports.renameSync = noopSync;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -6,112 +6,178 @@
 
 'use strict';
 
-const fs = require('./backend');
+const backend = require('./backend');
 const extra = require('./extra');
 const features = require('./features');
 
-/*
- * Extra
- */
+const fs = {
+  ...backend,
 
-fs.copy = extra.copy;
-fs.copySync = extra.copySync;
-fs.empty = extra.empty;
-fs.emptySync = extra.emptySync;
-fs.exists = extra.exists;
-fs.existsSync = extra.existsSync;
-fs.lstatTry = extra.lstatTry;
-fs.lstatTrySync = extra.lstatTrySync;
-fs.mkdirp = extra.mkdirp;
-fs.mkdirpSync = extra.mkdirpSync;
-fs.move = extra.move;
-fs.moveSync = extra.moveSync;
-fs.outputFile = extra.outputFile;
-fs.outputFileSync = extra.outputFileSync;
-fs.readJSON = extra.readJSON;
-fs.readJSONSync = extra.readJSONSync;
-fs.remove = extra.remove;
-fs.removeSync = extra.removeSync;
-fs.rimraf = extra.remove; // Compat.
-fs.rimrafSync = extra.removeSync; // Compat.
-fs.statTry = extra.statTry;
-fs.statTrySync = extra.statTrySync;
-fs.stats = extra.stats;
-fs.statsSync = extra.statsSync;
-fs.statsTry = extra.statsTry;
-fs.statsTrySync = extra.statsTrySync;
-fs.traverse = extra.traverse;
-fs.traverseSync = extra.traverseSync;
-fs.walk = extra.walk;
-fs.walkSync = extra.walkSync;
-fs.writeJSON = extra.writeJSON;
-fs.writeJSONSync = extra.writeJSONSync;
+  handle: null,
+
+  /*
+   * Extra
+   */
+
+  copy: extra.copy,
+  copySync: extra.copySync,
+  empty: extra.empty,
+  emptySync: extra.emptySync,
+  exists: extra.exists,
+  existsSync: extra.existsSync,
+  lstatTry: extra.lstatTry,
+  lstatTrySync: extra.lstatTrySync,
+  mkdirp: extra.mkdirp,
+  mkdirpSync: extra.mkdirpSync,
+  move: extra.move,
+  moveSync: extra.moveSync,
+  outputFile: extra.outputFile,
+  outputFileSync: extra.outputFileSync,
+  readJSON: extra.readJSON,
+  readJSONSync: extra.readJSONSync,
+  remove: extra.remove,
+  removeSync: extra.removeSync,
+  rimraf: extra.remove, // Compat.
+  rimrafSync: extra.removeSync, // Compat.
+  statTry: extra.statTry,
+  statTrySync: extra.statTrySync,
+  stats: extra.stats,
+  statsSync: extra.statsSync,
+  statsTry: extra.statsTry,
+  statsTrySync: extra.statsTrySync,
+  traverse: extra.traverse,
+  traverseSync: extra.traverseSync,
+  walk: extra.walk,
+  walkSync: extra.walkSync,
+  writeJSON: extra.writeJSON,
+  writeJSONSync: extra.writeJSONSync,
+
+  /*
+   * Info
+   */
+
+  features: features,
+  unsupported: false
+};
 
 /*
  * Promises
  */
 
 if (features.USE_STABLE_PROMISES) {
-  const native = fs.realpath.native;
+  // @ts-ignore
+  const native = backend.realpath.native;
 
-  fs.access = fs.promises.access;
-  fs.appendFile = fs.promises.appendFile;
-  fs.chmod = fs.promises.chmod;
-  fs.chown = fs.promises.chown;
-  fs.copyFile = fs.promises.copyFile;
-  fs.lchmod = fs.promises.lchmod;
-  fs.lchown = fs.promises.lchown;
-  fs.link = fs.promises.link;
-  fs.lstat = fs.promises.lstat;
-  fs.mkdir = fs.promises.mkdir;
-  fs.mkdtemp = fs.promises.mkdtemp;
-  fs.opendir = fs.promises.opendir;
-  fs.handle = fs.promises.open;
-  fs.readdir = fs.promises.readdir;
-  fs.readFile = fs.promises.readFile;
-  fs.readlink = fs.promises.readlink;
-  fs.realpath = fs.promises.realpath;
-  fs.rename = fs.promises.rename;
-  fs.rmdir = fs.promises.rmdir;
-  fs.stat = fs.promises.stat;
-  fs.symlink = fs.promises.symlink;
-  fs.truncate = fs.promises.truncate;
-  fs.unlink = fs.promises.unlink;
-  fs.utimes = fs.promises.utimes;
-  fs.writeFile = fs.promises.writeFile;
+  fs.access = backend.promises.access;
+  fs.appendFile = backend.promises.appendFile;
+  fs.chmod = backend.promises.chmod;
+  fs.chown = backend.promises.chown;
+  fs.copyFile = backend.promises.copyFile;
+  fs.lchmod = backend.promises.lchmod;
+  fs.lchown = backend.promises.lchown;
+  fs.link = backend.promises.link;
+  fs.lstat = backend.promises.lstat;
+  fs.mkdir = backend.promises.mkdir;
+  fs.mkdtemp = backend.promises.mkdtemp;
+  fs.opendir = backend.promises.opendir;
+  fs.handle = backend.promises.open;
+  fs.readdir = backend.promises.readdir;
+  fs.readFile = backend.promises.readFile;
+  fs.readlink = backend.promises.readlink;
+  fs.realpath = backend.promises.realpath;
+  fs.rename = backend.promises.rename;
+  fs.rmdir = backend.promises.rmdir;
+  fs.stat = backend.promises.stat;
+  fs.symlink = backend.promises.symlink;
+  fs.truncate = backend.promises.truncate;
+  fs.unlink = backend.promises.unlink;
+  fs.utimes = backend.promises.utimes;
+  fs.writeFile = backend.promises.writeFile;
 
   // fs.realpath.native does not
   // currently exist for promises.
-  if (!fs.realpath.native) {
+  // @ts-ignore
+  if (!backend.realpath.native) {
     fs.realpath = function realpath(...args) {
-      return fs.promises.realpath(...args);
+      // @ts-ignore
+      return backend.promises.realpath(...args);
     };
+    // @ts-ignore
     fs.realpath.native = native;
   }
 } else {
   let compat = null;
 
-  Object.defineProperty(fs, 'handle', {
-    configurable: true,
-    enumerable: false,
-    get() {
-      if (!compat)
-        compat = require('./compat');
+  Object.defineProperties(fs, {
+    handle: {
+      configurable: true,
+      enumerable: false,
+      get() {
+        if (!compat)
+          compat = require('./compat');
 
-      return compat.promises.open;
+        return compat.promises.open;
+      }
     }
   });
 }
 
-/*
- * Info
- */
+Object.defineProperties(fs, {
+  ReadStream: {
+    get() {
+      return backend.ReadStream;
+    },
+    set(val) {
+      backend.ReadStream = val;
+    }
+  },
+  WriteStream: {
+    get() {
+      return backend.WriteStream;
+    },
+    set(val) {
+      backend.WriteStream = val;
+    }
+  },
+  FileReadStream: {
+    get() {
+      return backend.ReadStream;
+    },
+    set(val) {
+      backend.ReadStream = val;
+    }
+  },
+  FileWriteStream: {
+    get() {
+      return backend.WriteStream;
+    },
+    set(val) {
+      backend.WriteStream = val;
+    }
+  },
+  promises: {
+    configurable: true,
+    get() {
+      return backend.promises;
+    }
+  }
+});
 
-fs.features = features;
-fs.unsupported = false;
+/** @typedef {import('fs').WriteStream} WriteStream */
+/** @typedef {import('fs').ReadStream} ReadStream */
+/** @typedef {import('fs').promises} promises */
+
+/**
+ * @typedef {Object} LazyFSProps
+ * @property {WriteStream} WriteStream
+ * @property {ReadStream} ReadStream
+ * @property {WriteStream} FileWriteStream
+ * @property {ReadStream} FileReadStream
+ * @property {promises} promises
+ */
 
 /*
  * Expose
  */
 
-module.exports = fs;
+module.exports = /** @type {fs & LazyFSProps} */(fs);

--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -8,53 +8,44 @@
 
 const compat = require('./compat');
 const features = require('./features');
-const fs = require('./modern');
-
-/*
- * Helpers
- */
-
-let cloned = false;
-
-// Future proofing:
-const clone = () => {
-  if (!cloned) {
-    fs.constants = Object.assign(Object.create(null), fs.constants);
-    cloned = true;
-  }
-};
+const modern = require('./modern');
 
 /*
  * Legacy
  */
 
+const legacy = {
+  ...modern,
+  constants: Object.assign(Object.create(null), modern.constants)
+};
+
 if (!features.HAS_STAT_NUMBERS
     || !features.HAS_STAT_BIGINTS
     || !features.HAS_STAT_NANO) {
-  fs.fstat = compat.fstat;
-  fs.fstatSync = compat.fstatSync;
-  fs.stat = compat.stat;
-  fs.statSync = compat.statSync;
-  fs.lstat = compat.lstat;
-  fs.lstatSync = compat.lstatSync;
+  legacy.fstat = compat.fstat;
+  legacy.fstatSync = compat.fstatSync;
+  legacy.stat = compat.stat;
+  legacy.statSync = compat.statSync;
+  legacy.lstat = compat.lstat;
+  legacy.lstatSync = compat.lstatSync;
 }
 
 if (!features.HAS_COPY_FILE_IMPL) {
-  clone();
-  fs.constants.COPYFILE_EXCL = compat.COPYFILE_EXCL;
-  fs.constants.COPYFILE_FICLONE = compat.COPYFILE_FICLONE;
-  fs.constants.COPYFILE_FICLONE_FORCE = compat.COPYFILE_FICLONE_FORCE;
-  fs.copyFile = compat.copyFile;
-  fs.copyFileSync = compat.copyFileSync;
+  legacy.constants.COPYFILE_EXCL = compat.COPYFILE_EXCL;
+  legacy.constants.COPYFILE_FICLONE = compat.COPYFILE_FICLONE;
+  legacy.constants.COPYFILE_FICLONE_FORCE = compat.COPYFILE_FICLONE_FORCE;
+  legacy.copyFile = compat.copyFile;
+  legacy.copyFileSync = compat.copyFileSync;
 }
 
 if (!features.HAS_REALPATH_NATIVE_IMPL) {
-  fs.realpath = compat.realpath;
-  fs.realpathSync = compat.realpathSync;
+  legacy.realpath = compat.realpath;
+  // @ts-ignore
+  legacy.realpathSync = compat.realpathSync;
 }
 
 if (!features.HAS_PROMISES_IMPL) {
-  Object.defineProperty(fs, 'promises', {
+  Object.defineProperty(modern, 'promises', {
     configurable: true,
     enumerable: false,
     get() {
@@ -64,49 +55,108 @@ if (!features.HAS_PROMISES_IMPL) {
 }
 
 if (!features.HAS_DIRENT_IMPL) {
-  fs.readdir = compat.readdir;
-  fs.readdirSync = compat.readdirSync;
-  fs.Dirent = compat.Dirent;
+  legacy.readdir = compat.readdir;
+  // @ts-ignore
+  legacy.readdirSync = compat.readdirSync;
+  legacy.Dirent = compat.Dirent;
 }
 
 if (!features.HAS_RW_TYPED_ARRAY) {
-  fs.read = compat.read;
-  fs.readSync = compat.readSync;
-  fs.write = compat.write;
-  fs.writeSync = compat.writeSync;
-  fs.writeFile = compat.writeFile;
-  fs.writeFileSync = compat.writeFileSync;
+  legacy.read = compat.read;
+  legacy.readSync = compat.readSync;
+  legacy.write = compat.write;
+  legacy.writeSync = compat.writeSync;
+  legacy.writeFile = compat.writeFile;
+  legacy.writeFileSync = compat.writeFileSync;
 }
 
 if (!features.HAS_RECURSIVE_MKDIR) {
-  fs.mkdir = compat.mkdir;
-  fs.mkdirSync = compat.mkdirSync;
+  legacy.mkdir = compat.mkdir;
+  // @ts-ignore
+  legacy.mkdirSync = compat.mkdirSync;
 }
 
 if (!features.HAS_OPTIONAL_FLAGS) {
-  fs.open = compat.open;
-  fs.openSync = compat.openSync;
+  legacy.open = compat.open;
+  legacy.openSync = compat.openSync;
 }
 
 if (!features.HAS_WRITEV_IMPL) {
-  fs.writev = compat.writev;
-  fs.writevSync = compat.writevSync;
+  legacy.writev = compat.writev;
+  legacy.writevSync = compat.writevSync;
 }
 
 if (!features.HAS_RECURSIVE_RMDIR) {
-  fs.rmdir = compat.rmdir;
-  fs.rmdirSync = compat.rmdirSync;
+  legacy.rmdir = compat.rmdir;
+  legacy.rmdirSync = compat.rmdirSync;
 }
 
 if (!features.HAS_OPENDIR_IMPL) {
-  fs.opendir = compat.opendir;
-  fs.opendirSync = compat.opendirSync;
-  fs.Dir = compat.Dir;
+  legacy.opendir = compat.opendir;
+  // @ts-ignore
+  legacy.opendirSync = compat.opendirSync;
+  // @ts-ignore
+  legacy.Dir = compat.Dir;
 }
+
+/** @typedef {import('fs').WriteStream} WriteStream */
+/** @typedef {import('fs').ReadStream} ReadStream */
+/** @typedef {import('fs').promises} promises */
+
+/**
+ * @typedef {Object} LazyFSProps
+ * @property {WriteStream} WriteStream
+ * @property {ReadStream} ReadStream
+ * @property {WriteStream} FileWriteStream
+ * @property {ReadStream} FileReadStream
+ * @property {promises} promises
+ */
+
+Object.defineProperties(legacy, {
+  ReadStream: {
+    get() {
+      return modern.ReadStream;
+    },
+    set(val) {
+      modern.ReadStream = val;
+    }
+  },
+  WriteStream: {
+    get() {
+      return modern.WriteStream;
+    },
+    set(val) {
+      modern.WriteStream = val;
+    }
+  },
+  FileReadStream: {
+    get() {
+      return modern.ReadStream;
+    },
+    set(val) {
+      modern.ReadStream = val;
+    }
+  },
+  FileWriteStream: {
+    get() {
+      return modern.WriteStream;
+    },
+    set(val) {
+      modern.WriteStream = val;
+    }
+  },
+  promises: {
+    configurable: true,
+    enumerable: false,
+    get() {
+      return modern.promises;
+    }
+  }
+});
 
 // A few things still need patching even if we have native promises.
 if (features.HAS_PROMISES_IMPL && !features.HAS_OPENDIR_IMPL) {
-  const getter = Object.getOwnPropertyDescriptor(fs, 'promises').get;
+  const getter = Object.getOwnPropertyDescriptor(modern, 'promises').get;
 
   const getPromises = () => {
     if (features.HAS_STABLE_PROMISES)
@@ -125,7 +175,7 @@ if (features.HAS_PROMISES_IMPL && !features.HAS_OPENDIR_IMPL) {
 
   let promises = null;
 
-  Object.defineProperty(fs, 'promises', {
+  Object.defineProperty(legacy, 'promises', {
     configurable: true,
     enumerable: false,
     get() {
@@ -172,4 +222,4 @@ if (features.HAS_PROMISES_IMPL && !features.HAS_OPENDIR_IMPL) {
  * Expose
  */
 
-module.exports = fs;
+module.exports = /** @type {legacy & LazyFSProps} */(legacy);

--- a/lib/modern.js
+++ b/lib/modern.js
@@ -11,93 +11,93 @@
 const fs = require('fs');
 const {promisify} = require('./util');
 
+const modern = {};
+
 /*
  * Expose
  */
 
-exports.access = promisify(fs.access);
-exports.accessSync = fs.accessSync;
-exports.appendFile = promisify(fs.appendFile);
-exports.appendFileSync = fs.appendFileSync;
-exports.chmod = promisify(fs.chmod);
-exports.chmodSync = fs.chmodSync;
-exports.chown = promisify(fs.chown);
-exports.chownSync = fs.chownSync;
-exports.close = promisify(fs.close);
-exports.closeSync = fs.closeSync;
-exports.constants = fs.constants;
-exports.copyFile = promisify(fs.copyFile);
-exports.copyFileSync = fs.copyFileSync;
-exports.createReadStream = fs.createReadStream;
-exports.createWriteStream = fs.createWriteStream;
-exports.exists = null;
-exports.existsSync = fs.existsSync;
-exports.fchmod = promisify(fs.fchmod);
-exports.fchmodSync = fs.fchmodSync;
-exports.fchown = promisify(fs.fchown);
-exports.fchownSync = fs.fchownSync;
-exports.fdatasync = promisify(fs.fdatasync);
-exports.fdatasyncSync = fs.fdatasyncSync;
-exports.fstat = promisify(fs.fstat);
-exports.fstatSync = fs.fstatSync;
-exports.fsync = promisify(fs.fsync);
-exports.fsyncSync = fs.fsyncSync;
-exports.ftruncate = promisify(fs.ftruncate);
-exports.ftruncateSync = fs.ftruncateSync;
-exports.futimes = promisify(fs.futimes);
-exports.futimesSync = fs.futimesSync;
-exports.lchmod = promisify(fs.lchmod);
-exports.lchmodSync = fs.lchmodSync;
-exports.lchown = promisify(fs.lchown);
-exports.lchownSync = fs.lchownSync;
-exports.link = promisify(fs.link);
-exports.linkSync = fs.linkSync;
-exports.lstat = promisify(fs.lstat);
-exports.lstatSync = fs.lstatSync;
-exports.mkdir = promisify(fs.mkdir);
-exports.mkdirSync = fs.mkdirSync;
-exports.mkdtemp = promisify(fs.mkdtemp);
-exports.mkdtempSync = fs.mkdtempSync;
-exports.open = promisify(fs.open);
-exports.openSync = fs.openSync;
-exports.opendir = promisify(fs.opendir);
-exports.opendirSync = fs.opendirSync;
-exports.read = null;
-exports.readSync = fs.readSync;
-exports.readdir = promisify(fs.readdir);
-exports.readdirSync = fs.readdirSync;
-exports.readFile = promisify(fs.readFile);
-exports.readFileSync = fs.readFileSync;
-exports.readlink = promisify(fs.readlink);
-exports.readlinkSync = fs.readlinkSync;
-exports.realpath = promisify(fs.realpath);
-exports.realpath.native = promisify(fs.realpath.native);
-exports.realpathSync = fs.realpathSync;
-exports.rename = promisify(fs.rename);
-exports.renameSync = fs.renameSync;
-exports.rmdir = promisify(fs.rmdir);
-exports.rmdirSync = fs.rmdirSync;
-exports.stat = promisify(fs.stat);
-exports.statSync = fs.statSync;
-exports.symlink = promisify(fs.symlink);
-exports.symlinkSync = fs.symlinkSync;
-exports.truncate = promisify(fs.truncate);
-exports.truncateSync = fs.truncateSync;
-exports.unlink = promisify(fs.unlink);
-exports.unlinkSync = fs.unlinkSync;
-exports.unwatchFile = fs.unwatchFile;
-exports.utimes = promisify(fs.utimes);
-exports.utimesSync = fs.utimesSync;
-exports.watch = fs.watch;
-exports.watchFile = fs.watchFile;
-exports.write = null;
-exports.writeSync = fs.writeSync;
-exports.writeFile = promisify(fs.writeFile);
-exports.writeFileSync = fs.writeFileSync;
-exports.writev = promisify(fs.writev);
-exports.writevSync = fs.writevSync;
+modern.access = promisify(fs.access);
+modern.accessSync = fs.accessSync;
+modern.appendFile = promisify(fs.appendFile);
+modern.appendFileSync = fs.appendFileSync;
+modern.chmod = promisify(fs.chmod);
+modern.chmodSync = fs.chmodSync;
+modern.chown = promisify(fs.chown);
+modern.chownSync = fs.chownSync;
+modern.close = promisify(fs.close);
+modern.closeSync = fs.closeSync;
+modern.constants = fs.constants;
+modern.copyFile = promisify(fs.copyFile);
+modern.copyFileSync = fs.copyFileSync;
+modern.createReadStream = fs.createReadStream;
+modern.createWriteStream = fs.createWriteStream;
+modern.existsSync = fs.existsSync;
+modern.fchmod = promisify(fs.fchmod);
+modern.fchmodSync = fs.fchmodSync;
+modern.fchown = promisify(fs.fchown);
+modern.fchownSync = fs.fchownSync;
+modern.fdatasync = promisify(fs.fdatasync);
+modern.fdatasyncSync = fs.fdatasyncSync;
+modern.fstat = promisify(fs.fstat);
+modern.fstatSync = fs.fstatSync;
+modern.fsync = promisify(fs.fsync);
+modern.fsyncSync = fs.fsyncSync;
+modern.ftruncate = promisify(fs.ftruncate);
+modern.ftruncateSync = fs.ftruncateSync;
+modern.futimes = promisify(fs.futimes);
+modern.futimesSync = fs.futimesSync;
+modern.lchmod = promisify(fs.lchmod);
+modern.lchmodSync = fs.lchmodSync;
+modern.lchown = promisify(fs.lchown);
+modern.lchownSync = fs.lchownSync;
+modern.link = promisify(fs.link);
+modern.linkSync = fs.linkSync;
+modern.lstat = promisify(fs.lstat);
+modern.lstatSync = fs.lstatSync;
+modern.mkdir = promisify(fs.mkdir);
+modern.mkdirSync = fs.mkdirSync;
+modern.mkdtemp = promisify(fs.mkdtemp);
+modern.mkdtempSync = fs.mkdtempSync;
+modern.open = promisify(fs.open);
+modern.openSync = fs.openSync;
+modern.opendir = promisify(fs.opendir);
+modern.opendirSync = fs.opendirSync;
+modern.readSync = fs.readSync;
+modern.readdir = promisify(fs.readdir);
+modern.readdirSync = fs.readdirSync;
+modern.readFile = promisify(fs.readFile);
+modern.readFileSync = fs.readFileSync;
+modern.readlink = promisify(fs.readlink);
+modern.readlinkSync = fs.readlinkSync;
+modern.realpath = promisify(fs.realpath);
+// @ts-ignore
+modern.realpath.native = promisify(fs.realpath.native);
+modern.realpathSync = fs.realpathSync;
+modern.rename = promisify(fs.rename);
+modern.renameSync = fs.renameSync;
+modern.rmdir = promisify(fs.rmdir);
+modern.rmdirSync = fs.rmdirSync;
+modern.stat = promisify(fs.stat);
+modern.statSync = fs.statSync;
+modern.symlink = promisify(fs.symlink);
+modern.symlinkSync = fs.symlinkSync;
+modern.truncate = promisify(fs.truncate);
+modern.truncateSync = fs.truncateSync;
+modern.unlink = promisify(fs.unlink);
+modern.unlinkSync = fs.unlinkSync;
+modern.unwatchFile = fs.unwatchFile;
+modern.utimes = promisify(fs.utimes);
+modern.utimesSync = fs.utimesSync;
+modern.watch = fs.watch;
+modern.watchFile = fs.watchFile;
+modern.writeSync = fs.writeSync;
+modern.writeFile = promisify(fs.writeFile);
+modern.writeFileSync = fs.writeFileSync;
+modern.writev = promisify(fs.writev);
+modern.writevSync = fs.writevSync;
 
-exports.exists = function exists(file) {
+modern.exists = function exists(file) {
   return new Promise(function(resolve, reject) {
     try {
       fs.exists(file, resolve);
@@ -107,7 +107,7 @@ exports.exists = function exists(file) {
   });
 };
 
-exports.read = function read(fd, buffer, offset, length, position) {
+modern.read = function read(fd, buffer, offset, length, position) {
   return new Promise(function(resolve, reject) {
     const cb = function(err, bytes, buffer) {
       if (err) {
@@ -125,7 +125,7 @@ exports.read = function read(fd, buffer, offset, length, position) {
   });
 };
 
-exports.write = function write(fd, buffer, offset, length, position) {
+modern.write = function write(fd, buffer, offset, length, position) {
   return new Promise(function(resolve, reject) {
     const cb = function(err, bytes, buffer) {
       if (err) {
@@ -156,15 +156,24 @@ exports.write = function write(fd, buffer, offset, length, position) {
   });
 };
 
-exports.F_OK = fs.constants.F_OK || 0;
-exports.R_OK = fs.constants.R_OK || 0;
-exports.W_OK = fs.constants.W_OK || 0;
-exports.X_OK = fs.constants.X_OK || 0;
+modern.F_OK = fs.constants.F_OK || 0;
+modern.R_OK = fs.constants.R_OK || 0;
+modern.W_OK = fs.constants.W_OK || 0;
+modern.X_OK = fs.constants.X_OK || 0;
 
-exports.Dirent = fs.Dirent;
-exports.Stats = fs.Stats;
+modern.Dirent = fs.Dirent;
+modern.Stats = fs.Stats;
 
-Object.defineProperties(exports, {
+/**
+ * @typedef {Object} LazyFSProps
+ * @property {fs.WriteStream} WriteStream
+ * @property {fs.ReadStream} ReadStream
+ * @property {fs.WriteStream} FileWriteStream
+ * @property {fs.ReadStream} FileReadStream
+ * @property {fs.promises} promises
+ */
+
+Object.defineProperties(modern, {
   ReadStream: {
     get() {
       return fs.ReadStream;
@@ -181,6 +190,22 @@ Object.defineProperties(exports, {
       fs.WriteStream = val;
     }
   },
+  FileReadStream: {
+    get() {
+      return fs.ReadStream;
+    },
+    set(val) {
+      fs.ReadStream = val;
+    }
+  },
+  FileWriteStream: {
+    get() {
+      return fs.WriteStream;
+    },
+    set(val) {
+      fs.WriteStream = val;
+    }
+  },
   promises: {
     configurable: true,
     enumerable: false,
@@ -189,3 +214,9 @@ Object.defineProperties(exports, {
     }
   }
 });
+
+/*
+ * Expose
+ */
+
+module.exports = /* @type {modern & LazyFSProps} */(modern);

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const {resolve} = require('path');
-const {ArgError} = require('./error');
+const {ArgError, TypeCodeError} = require('./error');
 
 /*
  * Constants
@@ -134,19 +134,19 @@ function fileURLToPath(uri) {
   try {
     uri = url.parse(uri);
   } catch (e) {
-    const err = new TypeError(`Invalid URL: ${uri}`);
+    const err = new TypeCodeError(`Invalid URL: ${uri}`);
     err.code = 'ERR_INVALID_URL';
     throw err;
   }
 
   if (uri.protocol !== 'file:') {
-    const err = new TypeError('The URL must be of scheme file');
+    const err = new TypeCodeError('The URL must be of scheme file');
     err.code = 'ERR_INVALID_URL_SCHEME';
     throw err;
   }
 
   if (uri.port != null) {
-    const err = new TypeError(`Invalid URL: ${uri.href}`);
+    const err = new TypeCodeError(`Invalid URL: ${uri.href}`);
     err.code = 'ERR_INVALID_URL';
     throw err;
   }
@@ -155,7 +155,7 @@ function fileURLToPath(uri) {
 
   if (!WINDOWS) {
     if (hostname !== '' && hostname !== 'localhost') {
-      const err = new TypeError('File URL host be "localhost" or empty');
+      const err = new TypeCodeError('File URL host be "localhost" or empty');
       err.code = 'ERR_INVALID_FILE_URL_HOST';
       throw err;
     }
@@ -165,7 +165,7 @@ function fileURLToPath(uri) {
         const third = pathname.codePointAt(i + 2) | 0x20;
 
         if (pathname[i + 1] === '2' && third === 102) {
-          const err = new TypeError('File URL path must '
+          const err = new TypeCodeError('File URL path must '
                                   + 'not include encoded '
                                   + '/ characters');
           err.code = 'ERR_INVALID_FILE_URL_PATH';
@@ -188,7 +188,7 @@ function fileURLToPath(uri) {
 
       if ((pathname[i + 1] === '2' && third === 102)
           || (pathname[i + 1] === '5' && third === 99)) {
-        const err = new TypeError('File URL path must '
+        const err = new TypeCodeError('File URL path must '
                                 + 'not include encoded '
                                 + '\\ or / characters');
         err.code = 'ERR_INVALID_FILE_URL_PATH';
@@ -213,7 +213,7 @@ function fileURLToPath(uri) {
   }
 
   if (letter < 0x61 || letter > 0x7a || sep !== 0x3a) {
-    const err = new TypeError('File URL path must be absolute');
+    const err = new TypeCodeError('File URL path must be absolute');
     err.code = 'ERR_INVALID_FILE_URL_PATH';
     throw err;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
-        "bmocha": "^2.1.8"
+        "bmocha": "^2.1.8",
+        "bts-type-deps": "^0.0.3"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -27,6 +28,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/bts-type-deps": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/bts-type-deps/-/bts-type-deps-0.0.3.tgz",
+      "integrity": "sha512-OQHGWhX5amae6Vj6ShlGaQu0sNCICgJ5YspNZPRzfR5RobrD+wjm5vkZK/J3EH5b/ymxqSWo9VkiFNpCxjaG2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
   "main": "./lib/bfile.js",
   "scripts": {
     "lint": "eslint lib/ test/",
+    "lint-types": "tsc -p .",
     "test": "npm run test-default && npm run test-compat && npm run test-stable",
     "test-default": "bmocha ./test/*-test.js",
     "test-compat": "bmocha -e BFILE_FORCE_COMPAT=1 ./test/*-test.js",
     "test-stable": "bmocha -e BFILE_FORCE_STABLE=1 ./test/*-test.js"
   },
   "devDependencies": {
-    "bmocha": "^2.1.8"
+    "bmocha": "^2.1.8",
+    "bts-type-deps": "^0.0.3"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "include": [
+    "lib/**/*.js",
+    "xx.js"
+  ],
+  "compilerOptions": {
+    "rootDir": ".",
+    "target": "ES2020",
+    "lib": [
+      "ES2020"
+    ],
+
+    "noEmit": true,
+
+    "allowJs": true,
+    "checkJs": true,
+    "maxNodeModuleJsDepth": 10,
+
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+
+    "stripInternal": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+
+    "typeRoots": [
+      "node_modules/bts-type-deps/types"
+    ]
+  }
+}


### PR DESCRIPTION
Restructure the initialization little bit (to allow better type inference). Side effect to this is lazy loading definitions need to be repeated. Also lazy loaded types are not inferred so manually added to the return types.

https://github.com/handshake-org/hsd/issues/841